### PR TITLE
Mod version checker

### DIFF
--- a/src/main/java/com/suppergerrie2/sdrones/DroneMod.java
+++ b/src/main/java/com/suppergerrie2/sdrones/DroneMod.java
@@ -31,7 +31,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.registries.RegistryBuilder;
 
-@Mod(modid = Reference.MODID, name=Reference.MODNAME, version=Reference.VERSION, acceptedMinecraftVersions=Reference.ACCEPTED_MINECRAFT_VERSIONS)
+@Mod(modid = Reference.MODID, name=Reference.MODNAME, version=Reference.VERSION, updateJSON = Reference.UPDATE_URL, acceptedMinecraftVersions=Reference.ACCEPTED_MINECRAFT_VERSIONS)
 @Mod.EventBusSubscriber(modid=Reference.MODID)
 public class DroneMod {
 

--- a/src/main/java/com/suppergerrie2/sdrones/Reference.java
+++ b/src/main/java/com/suppergerrie2/sdrones/Reference.java
@@ -5,6 +5,7 @@ public class Reference {
 	public static final String MODID = "sdrones";
 	public static final String MODNAME = "Suppergerrie2's Drone Mod";
 	public static final String VERSION = "1.3.1";
-	public static final String ACCEPTED_MINECRAFT_VERSIONS = "[1.12]";
+	public static final String ACCEPTED_MINECRAFT_VERSIONS = "[1.12][1.12.1][1.12.2]";
+	public static final String MOD_URL = "https://raw.githubusercontent.com/suppergerrie2/ModJam5/master/update.json";
 	public static final String UPGRADE_REGISTRY = "drone_upgrades";
 }

--- a/src/main/java/com/suppergerrie2/sdrones/Reference.java
+++ b/src/main/java/com/suppergerrie2/sdrones/Reference.java
@@ -5,7 +5,7 @@ public class Reference {
 	public static final String MODID = "sdrones";
 	public static final String MODNAME = "Suppergerrie2's Drone Mod";
 	public static final String VERSION = "1.3.1";
-	public static final String ACCEPTED_MINECRAFT_VERSIONS = "[1.12]";
+	public static final String ACCEPTED_MINECRAFT_VERSIONS = "[1.12.2]";
 	public static final String UPDATE_URL = "https://raw.githubusercontent.com/suppergerrie2/ModJam5/master/update.json";
 	public static final String UPGRADE_REGISTRY = "drone_upgrades";
 }

--- a/src/main/java/com/suppergerrie2/sdrones/Reference.java
+++ b/src/main/java/com/suppergerrie2/sdrones/Reference.java
@@ -6,6 +6,6 @@ public class Reference {
 	public static final String MODNAME = "Suppergerrie2's Drone Mod";
 	public static final String VERSION = "1.3.1";
 	public static final String ACCEPTED_MINECRAFT_VERSIONS = "[1.12][1.12.1][1.12.2]";
-	public static final String MOD_URL = "https://raw.githubusercontent.com/suppergerrie2/ModJam5/master/update.json";
+	public static final String UPDATE_URL = "https://raw.githubusercontent.com/suppergerrie2/ModJam5/master/update.json";
 	public static final String UPGRADE_REGISTRY = "drone_upgrades";
 }

--- a/src/main/java/com/suppergerrie2/sdrones/Reference.java
+++ b/src/main/java/com/suppergerrie2/sdrones/Reference.java
@@ -5,7 +5,7 @@ public class Reference {
 	public static final String MODID = "sdrones";
 	public static final String MODNAME = "Suppergerrie2's Drone Mod";
 	public static final String VERSION = "1.3.1";
-	public static final String ACCEPTED_MINECRAFT_VERSIONS = "[1.12,1.12.2]";
+	public static final String ACCEPTED_MINECRAFT_VERSIONS = "[1.12]";
 	public static final String UPDATE_URL = "https://raw.githubusercontent.com/suppergerrie2/ModJam5/master/update.json";
 	public static final String UPGRADE_REGISTRY = "drone_upgrades";
 }

--- a/src/main/java/com/suppergerrie2/sdrones/Reference.java
+++ b/src/main/java/com/suppergerrie2/sdrones/Reference.java
@@ -5,7 +5,7 @@ public class Reference {
 	public static final String MODID = "sdrones";
 	public static final String MODNAME = "Suppergerrie2's Drone Mod";
 	public static final String VERSION = "1.3.1";
-	public static final String ACCEPTED_MINECRAFT_VERSIONS = "[1.12][1.12.1][1.12.2]";
+	public static final String ACCEPTED_MINECRAFT_VERSIONS = "[1.12,1.12.2]";
 	public static final String UPDATE_URL = "https://raw.githubusercontent.com/suppergerrie2/ModJam5/master/update.json";
 	public static final String UPGRADE_REGISTRY = "drone_upgrades";
 }

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,16 +1,14 @@
-[
-{
+[{
   "modid": "sdrones",
   "name": "Suppergerrie2's Drone Mod",
   "description": "This mod adds tiny drones. Made for ModJam 5",
   "version": "${version}",
   "mcversion": "${mcversion}",
-  "url": "",
-  "updateUrl": "",
+  "url": "https://minecraft.curseforge.com/projects/suppergerrie2s-drone-mod/files",
+  "updateUrl": "https://raw.githubusercontent.com/suppergerrie2/ModJam5/master/update.json",
   "authorList": ["suppergerrie2"],
   "credits": "Thanks Haze33E for creating the drone models! \nI also want to credit the forge team ofcourse!",
   "logoFile": "",
   "screenshots": [],
   "dependencies": []
-}
-]
+}]

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -7,7 +7,7 @@
   "url": "https://minecraft.curseforge.com/projects/suppergerrie2s-drone-mod/files",
   "updateUrl": "https://raw.githubusercontent.com/suppergerrie2/ModJam5/master/update.json",
   "authorList": ["suppergerrie2"],
-  "credits": "Thanks Haze33E for creating the drone models! \nI also want to credit the forge team ofcourse!",
+  "credits": "Thanks Haze33E for creating the drone models!\nI also want to credit the forge team of course!\nEricCreation (CurseForge) or VirxEC (GitHub) for version update notifications.",
   "logoFile": "",
   "screenshots": [],
   "dependencies": []

--- a/update.json
+++ b/update.json
@@ -4,7 +4,7 @@
 		"1.3.1": "Fixed drone not dropping spawn item when it was spawned with the last item of the stack.\nFixed crop farm drone not farming or breaking blocks when out of dirt.\nFixed drone_upgrade not in lang file."
 	},
 	"promos": {
-		"1.12-latest": "1.3.1",
-		"1.12-recommended": "1.3.1"
+		"1.12.2-latest": "1.3.1",
+		"1.12.2-recommended": "1.3.1"
 	}
 }

--- a/update.json
+++ b/update.json
@@ -3,12 +3,12 @@
 	"1.12.2": {
 		"1.3.1": "changelog here\nsupports special character like \\n"
 	},
-  "1.12.1": {
+  	"1.12.1": {
 		"1.3.1": "changelog here\nsupports special character like \\n"
-  },
-  "1.12": {
+	},
+	"1.12": {
 		"1.3.1": "changelog here\nsupports special character like \\n"
-  }
+	},
 	"promos": {
 		"1.12.2-latest": "1.3.1",
 		"1.12.2-recommended": "1.3.1",

--- a/update.json
+++ b/update.json
@@ -1,0 +1,20 @@
+{
+	"homepage": "https://minecraft.curseforge.com/projects/suppergerrie2s-drone-mod",
+	"1.12.2": {
+		"1.3.1": "changelog here\nsupports special character like \\n"
+	},
+  "1.12.1": {
+		"1.3.1": "changelog here\nsupports special character like \\n"
+  },
+  "1.12": {
+		"1.3.1": "changelog here\nsupports special character like \\n"
+  }
+	"promos": {
+		"1.12.2-latest": "1.3.1",
+		"1.12.2-recommended": "1.3.1",
+		"1.12.1-latest": "1.3.1",
+		"1.12.1-recommended": "1.3.1",
+		"1.12-latest": "1.3.1",
+		"1.12-recommended": "1.3.1"
+	}
+}

--- a/update.json
+++ b/update.json
@@ -1,19 +1,9 @@
 {
 	"homepage": "https://minecraft.curseforge.com/projects/suppergerrie2s-drone-mod",
-	"1.12.2": {
-		"1.3.1": "Fixed drone not dropping spawn item when it was spawned with the last item of the stack.\nFixed crop farm drone not farming or breaking blocks when out of dirt.\nFixed drone_upgrade not in lang file."
-	},
-  	"1.12.1": {
-		"1.3.1": "Fixed drone not dropping spawn item when it was spawned with the last item of the stack.\nFixed crop farm drone not farming or breaking blocks when out of dirt.\nFixed drone_upgrade not in lang file."
-	},
 	"1.12": {
 		"1.3.1": "Fixed drone not dropping spawn item when it was spawned with the last item of the stack.\nFixed crop farm drone not farming or breaking blocks when out of dirt.\nFixed drone_upgrade not in lang file."
 	},
 	"promos": {
-		"1.12.2-latest": "1.3.1",
-		"1.12.2-recommended": "1.3.1",
-		"1.12.1-latest": "1.3.1",
-		"1.12.1-recommended": "1.3.1",
 		"1.12-latest": "1.3.1",
 		"1.12-recommended": "1.3.1"
 	}

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
 	"homepage": "https://minecraft.curseforge.com/projects/suppergerrie2s-drone-mod",
-	"1.12": {
+	"1.12.2": {
 		"1.3.1": "Fixed drone not dropping spawn item when it was spawned with the last item of the stack.\nFixed crop farm drone not farming or breaking blocks when out of dirt.\nFixed drone_upgrade not in lang file."
 	},
 	"promos": {

--- a/update.json
+++ b/update.json
@@ -1,13 +1,13 @@
 {
 	"homepage": "https://minecraft.curseforge.com/projects/suppergerrie2s-drone-mod",
 	"1.12.2": {
-		"1.3.1": "changelog here\nsupports special character like \\n"
+		"1.3.1": "Fixed drone not dropping spawn item when it was spawned with the last item of the stack.\nFixed crop farm drone not farming or breaking blocks when out of dirt.\nFixed drone_upgrade not in lang file."
 	},
   	"1.12.1": {
-		"1.3.1": "changelog here\nsupports special character like \\n"
+		"1.3.1": "Fixed drone not dropping spawn item when it was spawned with the last item of the stack.\nFixed crop farm drone not farming or breaking blocks when out of dirt.\nFixed drone_upgrade not in lang file."
 	},
 	"1.12": {
-		"1.3.1": "changelog here\nsupports special character like \\n"
+		"1.3.1": "Fixed drone not dropping spawn item when it was spawned with the last item of the stack.\nFixed crop farm drone not farming or breaking blocks when out of dirt.\nFixed drone_upgrade not in lang file."
 	},
 	"promos": {
 		"1.12.2-latest": "1.3.1",


### PR DESCRIPTION
If you accept this, your mod will:

1. Check if another version of this mod has been released, and notify the user.
2. If the user chooses to, they will be direct to a download link for your mod. (I set it to your download page on CurseForge.)

Right now update.json is incomplete because idk what your changelog is.

All you have to do is change the version of your mod in Reference.java and update update.json (that file should be in the mod; should be on GitHub only) and then that's it! Your users will get a notification for your new version. Example? Download an old version of my mod at https://minecraft.curseforge.com/projects/rubies-mod then go in the game and next to mods you will see a green "emerald?" (idk what it is, Forge is weird), click on it, go to the mod, (should have the same symbol next to it) and you will see the changelog and update URL.